### PR TITLE
feat: Async interrupts

### DIFF
--- a/examples/blink-fast-slow-async.rs
+++ b/examples/blink-fast-slow-async.rs
@@ -1,0 +1,93 @@
+use anyhow::Result;
+use log::{error, info};
+use rppal_pfd::{
+    ChipSelect, HardwareAddress, InterruptMode, Level, PiFaceDigital, SpiBus, SpiMode,
+};
+use std::{sync::mpsc::channel, time::Duration};
+
+#[derive(Debug)]
+enum HardwareInterfaceMessage {
+    InterruptReceived,
+}
+
+fn main() -> Result<()> {
+    env_logger::init();
+    info!("Async blink started!");
+
+    println!("Use the push-buttons to control the blink rate via async interrupts:\n");
+    println!("  Button 1:  Faster");
+    println!("  Button 2:  Slower");
+    println!("  Button 3:  Quit\n");
+
+    let mut pfd = PiFaceDigital::new(
+        HardwareAddress::new(0).unwrap(),
+        SpiBus::Spi0,
+        ChipSelect::Cs0,
+        100_000,
+        SpiMode::Mode0,
+    )?;
+    pfd.init()?;
+
+    let mut faster_button = pfd.get_pull_up_input_pin(0)?;
+    let mut slower_button = pfd.get_pull_up_input_pin(1)?;
+    let mut quit_button = pfd.get_pull_up_input_pin(2)?;
+    let led = pfd.get_output_pin_low(2)?;
+
+    faster_button.set_interrupt(InterruptMode::BothEdges)?;
+    slower_button.set_interrupt(InterruptMode::BothEdges)?;
+    quit_button.set_interrupt(InterruptMode::BothEdges)?;
+
+    let mut period = 1.0;
+    let mut led_state = Level::High;
+    let mut quit = false;
+
+    let (tx, rx) = channel();
+
+    pfd.subscribe_async_interrupts(move |_| {
+        tx.send(HardwareInterfaceMessage::InterruptReceived)
+            .expect("Failed to send message");
+    })?;
+
+    // If there's an interrupt already active, we'll not detect the next one and never
+    // service it, so read INTCAP which will clear it if it is already active.
+    let _ = pfd.get_interrupt_capture()?;
+
+    while !quit {
+        led.write(led_state)?;
+
+        match rx.recv_timeout(Duration::from_secs_f64(period / 2.0)) {
+            Ok(msg) => {
+                println!("An interrupt happened (msg={msg:?})...");
+
+                let flags = pfd.get_interrupt_flags()?;
+                let inputs = pfd.get_interrupt_capture()?;
+                if (flags & 0x01) != 0 {
+                    println!("Got button 1 (0x{flags:02x})");
+                    if (inputs & 0x01) == 0 {
+                        period /= 2.0;
+                    }
+                } else if (flags & 0x02) != 0 {
+                    println!("Got button 2 (0x{flags:02x})");
+                    if (inputs & 0x02) == 0 {
+                        period *= 2.0;
+                    }
+                } else if (flags & 0x04) != 0 {
+                    println!("Got button 3 (0x{flags:02x})");
+                    if (inputs & 0x04) == 0 {
+                        quit = true;
+                    }
+                } else {
+                    error!("Got unmatched 0x{flags:02x}");
+                }
+            }
+            Err(_) => {
+                led_state = !led_state;
+            }
+        }
+    }
+
+    // Quit, leaving the LED off.
+    led.set_low()?;
+    println!("\nBlinking is done!\n");
+    Ok(())
+}

--- a/src/.markdownlint.json
+++ b/src/.markdownlint.json
@@ -1,0 +1,4 @@
+{
+    "MD013": false,
+    "MD041": false
+}

--- a/src/async-interrupts.md
+++ b/src/async-interrupts.md
@@ -1,3 +1,5 @@
+<!-- This file is included as a documentation comment in lib.rs -->
+
 Waits for interrupts across a set of InputPins in a separate thread
 
 Spawns a separate thread that then blocks until an interrupt is raised and then calls

--- a/src/async-interrupts.md
+++ b/src/async-interrupts.md
@@ -3,6 +3,15 @@ Waits for interrupts across a set of InputPins in a separate thread
 Spawns a separate thread that then blocks until an interrupt is raised and then calls
 the supplied callback.
 
+The provided callback is called with a single parameter `level` that represents the
+level on the _Raspberry Pi's GPIO_ input pin (not the MCP23S17). As the interrupts are
+active-low, this will always be `GpioLevel::Low` for the real code. The parameter is
+replaced with a dummy `bool` when the **mockspi** feature is enabled as the GPIO code
+cannot be guaranteed to compile in non-target environments so the feature-flag causes it
+to be skipped. Since this parameter is unlikely to be of interest, it will normally be
+an anonymous placeholder (_i.e._ `|_|`) and so will compile equally well with or without
+the **mockspi** feature.
+
 Note that a potential to deadlock exists if there is already an interrupt raised by the
 hardware when the async interrupts are enabled: the GPIO won't raise an interrupt as it
 will not see the High-Low transition but nothing will clear the existing interrupt.

--- a/src/async-interrupts.md
+++ b/src/async-interrupts.md
@@ -1,0 +1,114 @@
+Waits for interrupts across a set of InputPins in a separate thread
+
+Spawns a separate thread that then blocks until an interrupt is raised and then calls
+the supplied callback.
+
+Note that a potential to deadlock exists if there is already an interrupt raised by the
+hardware when the async interrupts are enabled: the GPIO won't raise an interrupt as it
+will not see the High-Low transition but nothing will clear the existing interrupt.
+A "dummy" read of INTFB through a call to [`PiFaceDigital::get_interrupt_capture()`]
+will ensure any existing interrupts are cleared.
+
+# Example usage
+
+```rust no_run
+use anyhow::Result;
+use log::{error, info};
+use rppal_pfd::{
+    ChipSelect, HardwareAddress, InterruptMode, Level, PiFaceDigital, SpiBus, SpiMode,
+};
+use std::{sync::mpsc::channel, time::Duration};
+
+#[derive(Debug)]
+enum HardwareInterfaceMessage {
+    InterruptReceived,
+}
+
+fn main() -> Result<()> {
+    env_logger::init();
+    info!("Async blink started!");
+
+    println!("Use the push-buttons to control the blink rate via async interrupts:\n");
+    println!("  Button 1:  Faster");
+    println!("  Button 2:  Slower");
+    println!("  Button 3:  Quit\n");
+
+    let mut pfd = PiFaceDigital::new(
+        HardwareAddress::new(0).unwrap(),
+        SpiBus::Spi0,
+        ChipSelect::Cs0,
+        100_000,
+        SpiMode::Mode0,
+    )?;
+    pfd.init()?;
+
+    let mut faster_button = pfd.get_pull_up_input_pin(0)?;
+    let mut slower_button = pfd.get_pull_up_input_pin(1)?;
+    let mut quit_button = pfd.get_pull_up_input_pin(2)?;
+    let led = pfd.get_output_pin_low(2)?;
+
+    faster_button.set_interrupt(InterruptMode::BothEdges)?;
+    slower_button.set_interrupt(InterruptMode::BothEdges)?;
+    quit_button.set_interrupt(InterruptMode::BothEdges)?;
+
+    let mut period = 1.0;
+    let mut led_state = Level::High;
+    let mut quit = false;
+
+    let (tx, rx) = channel();
+
+    pfd.subscribe_async_interrupts(move |_| {
+        tx.send(HardwareInterfaceMessage::InterruptReceived)
+            .expect("Failed to send message");
+    })?;
+
+    // If there's an interrupt already active, we'll not detect the next one and never
+    // service it, so read INTCAP which will clear it if it is already active.
+    let _ = pfd.get_interrupt_capture()?;
+
+    while !quit {
+        led.write(led_state)?;
+
+        match rx.recv_timeout(Duration::from_secs_f64(period / 2.0)) {
+            Ok(msg) => {
+                println!("An interrupt happened (msg={msg:?})...");
+
+                let flags = pfd.get_interrupt_flags()?;
+                let inputs = pfd.get_interrupt_capture()?;
+                if (flags & 0x01) != 0 {
+                    println!("Got button 1 (0x{flags:02x})");
+                    if (inputs & 0x01) == 0 {
+                        period /= 2.0;
+                    }
+                } else if (flags & 0x02) != 0 {
+                    println!("Got button 2 (0x{flags:02x})");
+                    if (inputs & 0x02) == 0 {
+                        period *= 2.0;
+                    }
+                } else if (flags & 0x04) != 0 {
+                    println!("Got button 3 (0x{flags:02x})");
+                    if (inputs & 0x04) == 0 {
+                        quit = true;
+                    }
+                } else {
+                    error!("Got unmatched 0x{flags:02x}");
+                }
+            }
+            Err(_) => {
+                led_state = !led_state;
+            }
+        }
+    }
+
+    // Quit, leaving the LED off.
+    led.set_low()?;
+    println!("\nBlinking is done!\n");
+    Ok(())
+}
+```
+
+# Testing
+
+Note that in testing environments or with the `mockspi` feature enabled, this
+is replaced with a dummy function that does not spawn a thread and will never invoke
+the callback function.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -580,7 +580,7 @@ impl PiFaceDigital {
         Ok(None)
     }
 
-    // Asynchronous interrupt poll (actual docs are include because two flavours of this
+    // Asynchronous interrupt poll (actual docs are included because two flavours of this
     // function exist).
     #[doc = include_str!("async-interrupts.md")]
     #[cfg(not(any(test, feature = "mockspi")))]
@@ -730,7 +730,7 @@ impl PiFaceDigital {
 
 impl Default for PiFaceDigital {
     /// Creates a default PiFaceDigital that:
-    /// 
+    ///
     /// - Is at hardware address `0`
     /// - On SPI bus `Spi0`
     /// - Uses chip-select `Cs0`
@@ -743,7 +743,8 @@ impl Default for PiFaceDigital {
             ChipSelect::Cs0,
             100_000,
             SpiMode::Mode0,
-        ).expect("Failed to create default PiFaceDigital")
+        )
+        .expect("Failed to create default PiFaceDigital")
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -728,6 +728,25 @@ impl PiFaceDigital {
     }
 }
 
+impl Default for PiFaceDigital {
+    /// Creates a default PiFaceDigital that:
+    /// 
+    /// - Is at hardware address `0`
+    /// - On SPI bus `Spi0`
+    /// - Uses chip-select `Cs0`
+    /// - Is clocked at 100kHz
+    /// - Uses SPI mode 0
+    fn default() -> Self {
+        PiFaceDigital::new(
+            HardwareAddress::new(0).unwrap(),
+            SpiBus::Spi0,
+            ChipSelect::Cs0,
+            100_000,
+            SpiMode::Mode0,
+        ).expect("Failed to create default PiFaceDigital")
+    }
+}
+
 impl InputPin {
     /// Reads the pin's logic level.
     #[inline]

--- a/src/sync-interrupts.md
+++ b/src/sync-interrupts.md
@@ -1,0 +1,72 @@
+Waits for interrupts across a set of InputPins.
+
+Blocks until an interrupt is raised and then returns a list of references to the
+pin or pins that were the source. Note that it is possible that none of the
+pins were actually the source of the error (though this is suspicious and will
+cause a warning log) in which case the returned vector will be empty.
+
+Each interrupt is represented by a tuple of a reference to the pin and the level
+on the pin when the interrupt happened.
+
+If the timeout expires the function will return [`None`].
+
+# Example usage
+
+```rust no_run
+use rppal_pfd::{ChipSelect, HardwareAddress, InterruptMode, PiFaceDigital, SpiBus, SpiMode};
+use std::time::Duration;
+
+// Create an instance of the driver for the device with the hardware address
+// (A1, A0) of 0b00 on SPI bus 0 clocked at 100kHz. The address bits are set using
+// JP1 and JP2 on the PiFace Digital board.
+let mut pfd = PiFaceDigital::new(
+    HardwareAddress::new(0).expect("Invalid hardware address"),
+    SpiBus::Spi0,
+    ChipSelect::Cs0,
+    100_000,
+    SpiMode::Mode0,
+)
+.expect("Failed to create PiFace Digital");
+
+// Creating interrupt pin on the fourth switch on the PiFace Digital card.
+let mut interrupt_pin1 = pfd.get_pull_up_input_pin(3).expect("Bad pin");
+interrupt_pin1.set_interrupt(InterruptMode::BothEdges).expect("Bad interrupt");
+
+// Creating interrupt pin on the third switch on the PiFace Digital card.
+let mut interrupt_pin2 = pfd.get_pull_up_input_pin(2).expect("Bad pin");
+interrupt_pin2.set_interrupt(InterruptMode::BothEdges).expect("Bad interrupt");
+
+loop {
+    // Wait one minute for a button press...
+    match pfd.poll_interrupts(
+        &[&interrupt_pin1, &interrupt_pin2],
+        false,
+        Some(Duration::from_secs(60)),
+    ) {
+        Ok(Some(interrupts)) => {
+            // Button(s) were pressed!
+            for (i, (pin, level)) in interrupts.iter().enumerate() {
+                let pin_no = pin.get_pin_number();
+                println!("Interrupt[{i}]: pin({pin_no}) is {level}");
+            }
+        }
+
+        Ok(None) => {
+            println!("Poll timed out");
+            break;
+        }
+
+        Err(e) => {
+            eprintln!("Poll failed with {e}");
+            break;
+        }
+    }
+}
+```
+
+# Testing
+
+Note that in testing environments or with the `mockspi` feature enabled, this
+is replaced with a dummy interrupt poll function that always returns as if a
+timeout occurred (even if specified timeout was "forever", which is frankly
+wrong!)

--- a/src/sync-interrupts.md
+++ b/src/sync-interrupts.md
@@ -1,3 +1,5 @@
+<!-- This file is included as a documentation comment in lib.rs -->
+
 Waits for interrupts across a set of InputPins.
 
 Blocks until an interrupt is raised and then returns a list of references to the


### PR DESCRIPTION
Support async interrupts: when an interrupt occurs, the specified callback or closure
gets invoked from its own thread.