### PR TITLE
Update dependency of rppal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ resolver = "2"
 [dependencies]
 log = "0.4.17"
 rppal-mcp23s17 = "0.0"
-rppal = "0.14.0"
+rppal = "0.18.0"
 thiserror = "1.0.37"
 
 [dev-dependencies]


### PR DESCRIPTION
Used on a raspberry pi model 5, the PiFaceDigital::new returns an "unknown model" error. After updating the upstream dependency, everything works as expected.